### PR TITLE
feat: add brute force protection tool skeleton

### DIFF
--- a/admin/tool/bruteforce/classes/observer.php
+++ b/admin/tool/bruteforce/classes/observer.php
@@ -1,0 +1,30 @@
+<?php
+namespace tool_bruteforce;
+
+// Event observer class.
+
+defined('MOODLE_INTERNAL') || die();
+
+class observer {
+    /**
+     * Handle failed login events.
+     *
+     * @param \core\event\user_login_failed $event
+     * @return void
+     */
+    public static function user_login_failed(\core\event\user_login_failed $event): void {
+        global $DB;
+        // TODO: Increment counters and apply blocking logic.
+    }
+
+    /**
+     * Handle successful login events.
+     *
+     * @param \core\event\user_loggedin $event
+     * @return void
+     */
+    public static function user_loggedin(\core\event\user_loggedin $event): void {
+        global $DB;
+        // TODO: Reset counters after successful login.
+    }
+}

--- a/admin/tool/bruteforce/classes/task/purge_blocks.php
+++ b/admin/tool/bruteforce/classes/task/purge_blocks.php
@@ -1,0 +1,27 @@
+<?php
+namespace tool_bruteforce\task;
+
+// Scheduled task to remove expired blocks.
+
+defined('MOODLE_INTERNAL') || die();
+
+class purge_blocks extends \core\task\scheduled_task {
+    /**
+     * Return the task name.
+     *
+     * @return string
+     */
+    public function get_name(): string {
+        return get_string('taskpurge', 'tool_bruteforce');
+    }
+
+    /**
+     * Execute the task.
+     *
+     * @return void
+     */
+    public function execute(): void {
+        global $DB;
+        // TODO: Delete expired blocks from tool_bruteforce_blocks table.
+    }
+}

--- a/admin/tool/bruteforce/cli/clearblocks.php
+++ b/admin/tool/bruteforce/cli/clearblocks.php
@@ -1,0 +1,28 @@
+<?php
+// CLI script to list and clear brute force blocks.
+
+define('CLI_SCRIPT', true);
+
+require(__DIR__ . '/../../../../config.php');
+require_once($CFG->libdir . '/clilib.php');
+
+list($options) = cli_get_params([
+    'list' => false,
+    'clear' => false,
+]);
+
+if ($options['list']) {
+    $blocks = $DB->get_records('tool_bruteforce_blocks');
+    foreach ($blocks as $block) {
+        cli_writeln("User: {$block->userid} IP: {$block->ip} Expires: " . userdate($block->expires));
+    }
+}
+
+if ($options['clear']) {
+    $DB->delete_records('tool_bruteforce_blocks');
+    cli_writeln('All blocks cleared.');
+}
+
+if (!$options['list'] && !$options['clear']) {
+    cli_writeln("Options:\n --list  List blocks\n --clear Clear all blocks");
+}

--- a/admin/tool/bruteforce/db/access.php
+++ b/admin/tool/bruteforce/db/access.php
@@ -1,0 +1,22 @@
+<?php
+// Capabilities for tool_bruteforce.
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+    'tool/bruteforce:manage' => [
+        'riskbitmask' => RISK_CONFIG,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+    'tool/bruteforce:viewreports' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+];

--- a/admin/tool/bruteforce/db/events.php
+++ b/admin/tool/bruteforce/db/events.php
@@ -1,0 +1,15 @@
+<?php
+// Event observers for tool_bruteforce.
+
+defined('MOODLE_INTERNAL') || die();
+
+$observers = [
+    [
+        'eventname' => '\\core\\event\\user_login_failed',
+        'callback' => '\\tool_bruteforce\\observer::user_login_failed',
+    ],
+    [
+        'eventname' => '\\core\\event\\user_loggedin',
+        'callback' => '\\tool_bruteforce\\observer::user_loggedin',
+    ],
+];

--- a/admin/tool/bruteforce/db/install.xml
+++ b/admin/tool/bruteforce/db/install.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<XMLDB PATH="admin/tool/bruteforce/db" VERSION="2025040100" COMMENT="Moodle XMLDB file" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <TABLES>
+    <TABLE NAME="tool_bruteforce_login_failures" COMMENT="Track failed login attempts">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false"/>
+        <FIELD NAME="ip" TYPE="char" LENGTH="45" NOTNULL="true" DEFAULT=""/>
+        <FIELD NAME="attempts" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="firstfail" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="lastfail" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="tool_bruteforce_blocks" COMMENT="Active blocks for users or IPs">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false"/>
+        <FIELD NAME="ip" TYPE="char" LENGTH="45" NOTNULL="true" DEFAULT=""/>
+        <FIELD NAME="expires" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0"/>
+        <FIELD NAME="reason" TYPE="char" LENGTH="255" NOTNULL="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="tool_bruteforce_whitelist" COMMENT="Whitelisted users or IP ranges">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false"/>
+        <FIELD NAME="ip" TYPE="char" LENGTH="45" NOTNULL="true" DEFAULT=""/>
+        <FIELD NAME="note" TYPE="char" LENGTH="255" NOTNULL="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="tool_bruteforce_blacklist" COMMENT="Blacklisted users or IP ranges">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false"/>
+        <FIELD NAME="ip" TYPE="char" LENGTH="45" NOTNULL="true" DEFAULT=""/>
+        <FIELD NAME="note" TYPE="char" LENGTH="255" NOTNULL="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/admin/tool/bruteforce/db/tasks.php
+++ b/admin/tool/bruteforce/db/tasks.php
@@ -1,0 +1,14 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+$tasks = [
+    [
+        'classname' => '\\tool_bruteforce\\task\\purge_blocks',
+        'blocking' => 0,
+        'minute' => '*/5',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*',
+    ],
+];

--- a/admin/tool/bruteforce/index.php
+++ b/admin/tool/bruteforce/index.php
@@ -1,0 +1,33 @@
+<?php
+// Admin dashboard for tool_bruteforce.
+
+require(__DIR__ . '/../../../config.php');
+
+require_login();
+$context = context_system::instance();
+require_capability('tool/bruteforce:viewreports', $context);
+
+$PAGE->set_url(new moodle_url('/admin/tool/bruteforce/index.php'));
+$PAGE->set_context($context);
+$PAGE->set_title(get_string('pluginname', 'tool_bruteforce'));
+$PAGE->set_heading(get_string('pluginname', 'tool_bruteforce'));
+
+echo $OUTPUT->header();
+
+$blocks = $DB->get_records('tool_bruteforce_blocks');
+if ($blocks) {
+    $table = new html_table();
+    $table->head = [
+        get_string('userid'),
+        get_string('ip', 'tool_bruteforce'),
+        get_string('expires', 'tool_bruteforce'),
+    ];
+    foreach ($blocks as $block) {
+        $table->data[] = [$block->userid, $block->ip, userdate($block->expires)];
+    }
+    echo html_writer::table($table);
+} else {
+    echo $OUTPUT->notification(get_string('noblocks', 'tool_bruteforce'), 'notifymessage');
+}
+
+echo $OUTPUT->footer();

--- a/admin/tool/bruteforce/lang/en/tool_bruteforce.php
+++ b/admin/tool/bruteforce/lang/en/tool_bruteforce.php
@@ -1,0 +1,10 @@
+<?php
+// Language strings for tool_bruteforce.
+
+$string['pluginname'] = 'Brute force protection';
+$string['ip'] = 'IP address';
+$string['expires'] = 'Expires';
+$string['noblocks'] = 'No active blocks';
+$string['bruteforce:manage'] = 'Manage brute force protection';
+$string['bruteforce:viewreports'] = 'View brute force reports';
+$string['taskpurge'] = 'Purge expired blocks';

--- a/admin/tool/bruteforce/version.php
+++ b/admin/tool/bruteforce/version.php
@@ -1,0 +1,10 @@
+<?php
+// Version details.
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'tool_bruteforce';
+$plugin->version   = 2025040100; // YYYYMMDD00.
+$plugin->requires  = 2024100700; // Moodle 4.5.
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->release   = '0.1';


### PR DESCRIPTION
## Summary
- add tool_bruteforce plugin skeleton with DB schema, capabilities, event observers, CLI, and admin dashboard

## Testing
- `php -l admin/tool/bruteforce/db/access.php`
- `php -l admin/tool/bruteforce/db/events.php`
- `php -l admin/tool/bruteforce/version.php`
- `php -l admin/tool/bruteforce/classes/observer.php`
- `php -l admin/tool/bruteforce/cli/clearblocks.php`
- `php -l admin/tool/bruteforce/index.php`
- `php -l admin/tool/bruteforce/classes/task/purge_blocks.php`
- `php -l admin/tool/bruteforce/db/tasks.php`
- `php -l admin/tool/bruteforce/lang/en/tool_bruteforce.php`

------
https://chatgpt.com/codex/tasks/task_e_688f8c20b400832a9ffa0b8320e92513